### PR TITLE
fix: Configure session cookie for HTTPS

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,10 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 # --- FastAPI App Initialization ---
 app = FastAPI()
 app.add_middleware(
-    SessionMiddleware, secret_key=os.getenv("APP_SECRET_KEY", secrets.token_hex(32))
+    SessionMiddleware,
+    secret_key=os.getenv("APP_SECRET_KEY", secrets.token_hex(32)),
+    https_only=True,  # Ensures cookies are only sent over HTTPS
+    same_site="lax"   # Recommended for OAuth callbacks and cross-site requests
 )
 templates = Jinja2Templates(directory="templates")
 


### PR DESCRIPTION
This change updates the FastAPI SessionMiddleware configuration to be more robust for production environments running behind a reverse proxy with HTTPS.

- Sets `https_only=True` to ensure session cookies are only sent over secure connections.
- Sets `same_site='lax'` as is recommended for OAuth redirect flows.

This should resolve the issue where your session was not being persisted after the Spotify OAuth callback on the Render platform.