### PR TITLE
refactor: Switch to manual synchronization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ gunicorn
 jinja2
 python-dotenv
 spotipy
-apscheduler
 itsdangerous

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
             box-shadow: 0 0 5px #a78bfa, 0 0 10px #a78bfa, 0 0 15px #a78bfa;
             transition: all 0.3s ease-in-out;
         }
-        .glow-button:hover {
+        .glow-button:hover:not(:disabled) {
             box-shadow: 0 0 10px #c4b5fd, 0 0 20px #c4b5fd, 0 0 30px #c4b5fd;
         }
         .card {
@@ -24,19 +24,12 @@
             backdrop-filter: blur(10px);
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
-        .toggle-checkbox:checked {
-            right: 0;
-            border-color: #4ade80;
-        }
-        .toggle-checkbox:checked + .toggle-label {
-            background-color: #4ade80;
-        }
     </style>
 </head>
 <body class="flex items-center justify-center min-h-screen">
     <div class="w-full max-w-2xl mx-auto p-8 rounded-xl card text-center">
         <h1 class="text-3xl font-bold mb-2 text-white">Spotify Liked Songs Sync</h1>
-        <p class="text-violet-300 mb-8">✨ Keep your playlists fresh, automatically. ✨</p>
+        <p class="text-violet-300 mb-8">✨ Manually sync your liked songs to a playlist. ✨</p>
 
         {% if user %}
             <div class="mb-6 flex flex-col items-center">
@@ -52,24 +45,21 @@
             <!-- Dashboard Content -->
             <div id="dashboard" class="text-left p-6 rounded-lg bg-gray-800/50 mb-6">
                 <div class="flex justify-between items-center mb-4">
-                    <h2 class="text-xl font-bold text-violet-300">Sync Dashboard</h2>
-                    <!-- Toggle Switch -->
-                    <div class="relative inline-block w-14 align-middle select-none transition duration-200 ease-in">
-                        <input type="checkbox" name="toggle" id="sync-toggle" class="toggle-checkbox absolute block w-7 h-7 rounded-full bg-white border-4 appearance-none cursor-pointer" onchange="toggleSync()"/>
-                        <label for="sync-toggle" class="toggle-label block overflow-hidden h-7 rounded-full bg-gray-600 cursor-pointer"></label>
-                    </div>
+                    <h2 class="text-xl font-bold text-violet-300">Manual Sync</h2>
+                    <button id="sync-button" onclick="startSync()" class="bg-violet-500 hover:bg-violet-600 text-white font-bold py-2 px-4 rounded-lg glow-button disabled:opacity-50 disabled:cursor-not-allowed">
+                        Sync Now
+                    </button>
                 </div>
 
                 <div id="status-display" class="space-y-2">
-                    <p>Playlist: <a id="playlist-link" href="#" target="_blank" class="font-mono text-green-400 hover:underline">Not available</a></p>
-                    <p>Status: <span id="status-text" class="font-mono text-green-400">Inactive</span></p>
-                    <p>Total Synced: <span id="synced-count" class="font-mono text-green-400">0</span></p>
+                    <p>Playlist: <a id="playlist-link" href="#" target="_blank" class="font-mono text-green-400 hover:underline">Sync to see</a></p>
+                    <p>Last Synced: <span id="synced-count" class="font-mono text-green-400">0</span> songs</p>
                 </div>
 
                 <div id="logs-container" class="mt-4">
-                     <h3 class="font-semibold text-gray-300 mb-2">Live Log:</h3>
-                     <div id="logs" class="h-40 overflow-y-auto bg-gray-900/70 p-3 rounded font-mono text-sm space-y-1">
-                        <!-- Logs will be inserted here -->
+                     <h3 class="font-semibold text-gray-300 mb-2">Sync Log:</h3>
+                     <div id="logs" class="h-48 overflow-y-auto bg-gray-900/70 p-3 rounded font-mono text-sm space-y-1">
+                        <p class="text-gray-500">Click "Sync Now" to start...</p>
                      </div>
                 </div>
             </div>
@@ -86,83 +76,55 @@
 
     {% if user %}
     <script>
-        const statusText = document.getElementById('status-text');
+        const syncButton = document.getElementById('sync-button');
         const playlistLink = document.getElementById('playlist-link');
         const syncedCount = document.getElementById('synced-count');
         const logsDiv = document.getElementById('logs');
 
-        let statusInterval;
-
-        async function toggleSync() {
-            const syncToggle = document.getElementById('sync-toggle');
-            const endpoint = syncToggle.checked ? '/start-sync' : '/stop-sync';
-            try {
-                const response = await fetch(endpoint, { method: 'POST' });
-                if (!response.ok) {
-                    throw new Error(`Failed to ${syncToggle.checked ? 'start' : 'stop'} sync`);
-                }
-                // Immediately fetch status to reflect change
-                fetchStatus();
-            } catch (error) {
-                console.error(error);
-                logsDiv.insertAdjacentHTML('afterbegin', `<p class="text-red-400">Error: ${error.message}</p>`);
-                // Revert toggle on failure
-                if(syncToggle) syncToggle.checked = !syncToggle.checked;
-            }
+        function updateLogs(logs) {
+            logsDiv.innerHTML = logs.map(log => {
+                let color = 'text-gray-400';
+                if (log.includes('🔄') || log.includes('Adding')) color = 'text-blue-300';
+                if (log.includes('✅')) color = 'text-green-300';
+                if (log.includes('🚨') || log.includes('Error')) color = 'text-red-400';
+                if (log.includes('🚀') || log.includes('started')) color = 'text-violet-300';
+                return `<p class="${color}">${log}</p>`;
+            }).join('');
         }
 
-        async function fetchStatus() {
-            // If the main dashboard element is gone, we're logged out, so stop polling.
-            const dashboard = document.getElementById('dashboard');
-            if (!dashboard) {
-                clearInterval(statusInterval);
-                return;
-            }
+        async function startSync() {
+            syncButton.disabled = true;
+            syncButton.textContent = 'Syncing...';
+            logsDiv.innerHTML = '<p class="text-violet-300">Initiating sync...</p>';
 
             try {
-                const response = await fetch('/sync-status');
+                const response = await fetch('/sync-now', { method: 'POST' });
                 const data = await response.json();
-                const syncToggle = document.getElementById('sync-toggle');
 
-                // Update toggle state
-                if(syncToggle) syncToggle.checked = data.is_running;
+                if (!response.ok) {
+                    throw new Error(data.detail || 'An unknown error occurred.');
+                }
 
-                // Update dashboard
-                statusText.textContent = data.is_running ? 'Active' : 'Inactive';
-                statusText.className = `font-mono ${data.is_running ? 'text-green-400 animate-pulse' : 'text-gray-400'}`;
+                // Update dashboard with results from the sync
+                updateLogs(data.logs);
+                syncedCount.textContent = `${data.synced_count} new song(s)`;
 
                 if(data.playlist_url) {
                     playlistLink.href = data.playlist_url;
                     playlistLink.textContent = data.playlist_name;
                 } else {
                     playlistLink.href = '#';
-                    playlistLink.textContent = 'Not created yet';
+                    playlistLink.textContent = 'Could not find or create playlist.';
                 }
 
-                syncedCount.textContent = data.synced_count;
-
-                // Update logs
-                logsDiv.innerHTML = data.logs.map(log => {
-                    let color = 'text-gray-400';
-                    if (log.includes('🔄') || log.includes('Synced')) color = 'text-blue-300';
-                    if (log.includes('✅')) color = 'text-green-300';
-                    if (log.includes('🚨') || log.includes('Error')) color = 'text-red-400';
-                    if (log.includes('🚀') || log.includes('Started')) color = 'text-violet-300';
-                    if (log.includes('🛑') || log.includes('Stopped')) color = 'text-yellow-300';
-                    return `<p class="${color}">${log}</p>`;
-                }).join('');
-
             } catch (error) {
-                console.error('Failed to fetch status:', error);
-                logsDiv.insertAdjacentHTML('afterbegin', `<p class="text-red-400">Could not connect to server.</p>`);
+                console.error('Failed to sync:', error);
+                logsDiv.innerHTML = `<p class="text-red-400">Error: ${error.message}</p>`;
+            } finally {
+                syncButton.disabled = false;
+                syncButton.textContent = 'Sync Now';
             }
         }
-
-        document.addEventListener('DOMContentLoaded', () => {
-            fetchStatus(); // Initial fetch
-            statusInterval = setInterval(fetchStatus, 5000); // Fetch every 5 seconds
-        });
-
     </script>
     {% endif %}
 </body>


### PR DESCRIPTION
This commit refactors the application to remove the automatic, scheduled synchronization in favor of a manual, user-triggered process. This provides you with more control and prevents hitting Spotify API rate limits.

Key changes:
- Removed `apscheduler` dependency and all related background scheduling logic.
- Replaced the `/start-sync` and `/stop-sync` endpoints with a single `/sync-now` endpoint.
- The UI toggle switch has been replaced with a "Sync Now" button.
- The `spotipy` client is now configured with an automatic retry strategy for `429 (Too Many Requests)` errors.
- The frontend now gets immediate feedback and logs from the manual sync operation.

## Sourcery Özeti

Otomatik zamanlanmış senkronizasyonu, anında geri bildirim ve loglar sağlayan manuel, kullanıcı tetiklemeli bir senkronizasyon süreciyle değiştirin.

Yeni Özellikler:
- İsteğe bağlı çalma listesi senkronizasyonu için bir `/sync-now` uç noktası tanıtıldı.
- Kullanıcı arayüzündeki açma/kapama anahtarı, canlı logları ve senkronizasyon sonuçlarını gösteren bir "Şimdi Senkronize Et" düğmesiyle değiştirildi.

İyileştirmeler:
- Spotipy istemcisi, hız limitlerinde ve geçici hatalarda otomatik yeniden denemeler yapacak şekilde yapılandırıldı.
- Küresel zamanlayıcı durumu yerine, istek başına durum nesneleri kullanarak senkronizasyon durumu yönetimi basitleştirildi.

Yapı:
- `apscheduler` bağımlılığı ve ilgili tüm zamanlama mantığı kaldırıldı.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace automatic scheduled syncing with a manual, user-triggered sync process that provides immediate feedback and logs.

New Features:
- Introduce a `/sync-now` endpoint for on-demand playlist synchronization.
- Swap the UI toggle switch for a "Sync Now" button that shows live logs and sync results.

Enhancements:
- Configure the Spotipy client with automatic retries on rate limits and transient errors.
- Simplify sync state handling by using per-request status objects instead of global scheduler state.

Build:
- Remove the `apscheduler` dependency and all related scheduling logic.

</details>