### PR TITLE
fix: Add critical warning for missing APP_SECRET_KEY

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,9 +16,23 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 
 # --- FastAPI App Initialization ---
 app = FastAPI()
+
+# Session Middleware Setup
+APP_SECRET_KEY = os.getenv("APP_SECRET_KEY")
+if not APP_SECRET_KEY:
+    APP_SECRET_KEY = secrets.token_hex(32)
+    logging.warning(
+        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+        "!!! WARNING: APP_SECRET_KEY is not set in the environment. !!!\n"
+        "!!! Using a temporary secret key.                            !!!\n"
+        "!!! Sessions will NOT persist across application restarts.   !!!\n"
+        "!!! Set APP_SECRET_KEY in your .env file or environment.     !!!\n"
+        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    )
+
 app.add_middleware(
     SessionMiddleware,
-    secret_key=os.getenv("APP_SECRET_KEY", secrets.token_hex(32)),
+    secret_key=APP_SECRET_KEY,
     https_only=True,
     same_site="lax"
 )


### PR DESCRIPTION
This commit adds a loud, critical warning message to the logs if the `APP_SECRET_KEY` environment variable is not set on application startup.

An unset secret key causes the session middleware to generate a new, temporary key on every restart. This invalidates all existing user sessions and is the most likely cause of the persistent login issues reported on the Render platform.

This change doesn't fix the issue directly but makes the root cause (an environment configuration error) obvious in the application logs, guiding you to the correct solution.