### PR TITLE
fix: Resolve circular import between main and spotify modules

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,6 @@ from .spotify import run_sync_logic
 # --- Basic Setup ---
 load_dotenv()
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-TARGET_PLAYLIST_NAME = "Liked Songs Sync ✨" # Keep it here for now or move to a config file
 
 # --- FastAPI App Initialization ---
 app = FastAPI()
@@ -65,11 +64,6 @@ def get_token_from_session(request: Request) -> dict | None:
 def get_spotify_client(token_info: dict) -> spotipy.Spotify:
     """Initializes a Spotipy client."""
     return spotipy.Spotify(auth=token_info['access_token'])
-
-def add_log(log_list: list, message: str):
-    """A helper function to add a timestamped log message."""
-    timestamp = datetime.datetime.now().strftime("%H:%M:%S")
-    log_list.insert(0, f"[{timestamp}] {message}")
 
 # --- FastAPI Routes ---
 @app.get("/", response_class=HTMLResponse)

--- a/app/spotify.py
+++ b/app/spotify.py
@@ -1,5 +1,13 @@
 import spotipy
-from .main import add_log, TARGET_PLAYLIST_NAME
+import datetime
+
+# Moved from main.py to resolve circular import
+TARGET_PLAYLIST_NAME = "Liked Songs Sync ✨"
+
+def add_log(log_list: list, message: str):
+    """A helper function to add a timestamped log message."""
+    timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+    log_list.insert(0, f"[{timestamp}] {message}")
 
 def _find_or_create_playlist(sp: spotipy.Spotify, user_id: str, logs: list) -> tuple[str | None, str | None]:
     """Finds the target playlist by name, or creates it if it doesn't exist."""


### PR DESCRIPTION
This commit fixes a critical `ImportError` that was caused by a circular dependency introduced during the refactoring process.

- `app/main.py` was importing `run_sync_logic` from `app/spotify.py`.
- `app/spotify.py` was importing `add_log` and `TARGET_PLAYLIST_NAME` from `app/main.py`.

The fix moves the shared `add_log` function and `TARGET_PLAYLIST_NAME` constant into the `app/spotify.py` module, breaking the circular dependency. This allows the application to start correctly.

## Sourcery Tarafından Özet

Paylaşılan günlük yardımcı fonksiyonunu ve çalma listesi adı sabitini `spotify` modülüne taşıyarak `main` ve `spotify` modülleri arasındaki dairesel içe aktarmayı kırın.

Hata Düzeltmeleri:
- `main.py` ve `spotify.py` arasındaki dairesel bağımlılıktan kaynaklanan `ImportError` giderildi.

İyileştirmeler:
- `add_log` fonksiyonu ve `TARGET_PLAYLIST_NAME` sabiti `main.py`'den `spotify.py`'ye taşındı.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Break the circular import between main and spotify modules by relocating the shared logging helper and playlist name constant to the spotify module

Bug Fixes:
- Resolve ImportError caused by circular dependency between main.py and spotify.py

Enhancements:
- Move add_log function and TARGET_PLAYLIST_NAME constant from main.py into spotify.py

</details>