### PR TITLE
fix: Use absolute imports to resolve startup error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,10 +10,10 @@ import spotipy
 import firebase_admin
 from firebase_admin import credentials
 
-from .core import config
-from .core.dependencies import create_spotify_oauth, get_token_from_session, get_spotify_client
-from .spotify import run_sync_logic
-from .ytmusic import routes as ytmusic_routes
+from app.core import config
+from app.core.dependencies import create_spotify_oauth, get_token_from_session, get_spotify_client
+from app.spotify import run_sync_logic
+from app.ytmusic import routes as ytmusic_routes
 
 # --- Basic Setup ---
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/app/spotify.py
+++ b/app/spotify.py
@@ -1,7 +1,7 @@
 import spotipy
 import datetime
 
-from ..core import config
+from app.core import config
 
 # Moved from main.py to resolve circular import
 TARGET_PLAYLIST_NAME = "Liked Songs Sync ✨"

--- a/app/ytmusic/auth.py
+++ b/app/ytmusic/auth.py
@@ -2,7 +2,7 @@ from google_auth_oauthlib.flow import Flow
 from firebase_admin import firestore
 from fastapi import HTTPException
 
-from ..core import config
+from app.core import config
 
 def create_google_oauth_flow():
     """Creates a Google OAuth Flow instance."""

--- a/app/ytmusic/routes.py
+++ b/app/ytmusic/routes.py
@@ -2,8 +2,8 @@ from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse
 import spotipy
 
-from ..core.dependencies import get_token_from_session, get_spotify_client
-from . import auth
+from app.core.dependencies import get_token_from_session, get_spotify_client
+from app.ytmusic import auth
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")


### PR DESCRIPTION
This commit fixes the `ImportError: attempted relative import beyond top-level package` by converting all internal application imports to be absolute from the `app` package root.

Relative imports (`.` and `..`) were causing issues with how gunicorn/uvicorn determines the top-level package. Switching to absolute imports (e.g., `from app.core import config` instead of `from .core import config` or `from ..core import config`) provides an unambiguous path for the Python interpreter.

This resolves the startup crash and makes the application's dependency structure more robust and explicit.

## Sourcery Özeti

Başlangıç hatalarını düzeltmek ve tutarlı içe aktarma çözümünü sağlamak için uygulamanın genelindeki tüm göreceli içe aktarmaları mutlak içe aktarmalarla değiştirin.

Hata Düzeltmeleri:
- Uygulama kökünden mutlak içe aktarmalar kullanarak göreceli içe aktarmalar için ImportError'u önleyin

İyileştirmeler:
- Daha net bağımlılık yapısı için dahili uygulama içe aktarmalarını mutlak yollara standartlaştırın

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace all relative imports with absolute imports across the application to fix startup errors and ensure consistent import resolution

Bug Fixes:
- Prevent ImportError for relative imports by using absolute imports from the app root

Enhancements:
- Standardize internal application imports to absolute paths for clearer dependency structure

</details>