### PR TITLE
fix: Add missing Jinja2Templates import in ytmusic routes

### DIFF
--- a/app/ytmusic/routes.py
+++ b/app/ytmusic/routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
 import spotipy
 
 from app.core.dependencies import get_token_from_session, get_spotify_client


### PR DESCRIPTION
This commit fixes a `NameError` crash on startup caused by a missing import in `app/ytmusic/routes.py`.

The `Jinja2Templates` class was being used without being imported, leading to the application failing to launch. The necessary import `from fastapi.templating import Jinja2Templates` has been added.