### PR TITLE
fix: Resolve infinite redirect loop for YT Music page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,7 @@ except Exception as e:
 app = FastAPI()
 
 # Include the YouTube Music router
-app.include_router(ytmusic_routes.router)
+app.include_router(ytmusic_routes.router, prefix="/ytmusic", tags=["YouTube Music"])
 
 # Session Middleware Setup
 if not config.APP_SECRET_KEY:

--- a/app/ytmusic/routes.py
+++ b/app/ytmusic/routes.py
@@ -26,7 +26,8 @@ def get_spotify_user(request: Request) -> dict:
 async def get_ytmusic_page(request: Request, spotify_user: dict = Depends(get_spotify_user)):
     """Renders the main page for the YouTube Music sync feature."""
     if not spotify_user:
-        return RedirectResponse(url="/?error=spotify_session_expired")
+        # If no spotify session, redirect to the main login page to start the flow.
+        return RedirectResponse(url="/login")
 
     # Check if the user has already linked their Google account
     google_creds = auth.get_credentials_from_firestore(spotify_user['id'])


### PR DESCRIPTION
This commit fixes two critical errors that caused an infinite redirect loop when you tried to access the `/ytmusic` page without a valid Spotify session.

1.  **Missing Router Prefix**: The `ytmusic_routes.router` was included in the main app without the `/ytmusic` prefix, causing incorrect URL resolution. I have now added the prefix.
2.  **Incorrect Redirect Logic**: The `/ytmusic` main page was redirecting to `/` if no Spotify session was found, which created a loop. It now correctly redirects to the main `/login` page to initiate the authentication flow.

These changes resolve the `ERR_TOO_MANY_REDIRECTS` browser error and ensure the application flow is logical.

## Sourcery tarafından Özet

Yönlendiricinin "/ytmusic" altına monte edildiğinden emin olarak ve oturumsuz yönlendirmeyi "/login" sayfasına işaret edecek şekilde güncelleyerek YT Müzik sayfasındaki sonsuz yönlendirme döngüsünü düzeltir.

Hata Düzeltmeleri:
- URL uyuşmazlıklarını çözmek için YouTube Müzik yönlendiricisini "/ytmusic" ön ekiyle monte edin
- Döngüleri önlemek için kimliği doğrulanmamış YT Müzik sayfası isteklerini "/?error=spotify_session_expired" yerine "/login" adresine yönlendirin

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix infinite redirect loop on YT Music page by ensuring the router is mounted under "/ytmusic" and updating the no-session redirect to point to the "/login" page.

Bug Fixes:
- Mount the YouTube Music router with the "/ytmusic" prefix to resolve URL mismatches
- Redirect unauthenticated YT Music page requests to "/login" instead of "/?error=spotify_session_expired" to avoid loops

</details>