### PR TITLE
fix(ytmusic): Import Jinja2Templates to resolve NameError

### DIFF
--- a/app/ytmusic/routes.py
+++ b/app/ytmusic/routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Request, Depends, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
 import spotipy
 
 from app.core.dependencies import get_token_from_session, get_spotify_client


### PR DESCRIPTION
The application was crashing on startup because `Jinja2Templates` was used in `app/ytmusic/routes.py` without being imported first.

This commit adds the necessary import statement from `fastapi.templating`, resolving the `NameError` and allowing the application to start correctly.