### PR TITLE
fix(ytmusic): Refresh expired token before YTMusic client initialization

### DIFF
--- a/app/ytmusic/client.py
+++ b/app/ytmusic/client.py
@@ -19,6 +19,12 @@ def get_ytmusic_client(google_creds: dict) -> YTMusic:
         scopes=google_creds.get('scopes')
     )
 
+    # We need to refresh the credentials to make sure the token is valid
+    if credentials.expired and credentials.refresh_token:
+        from google.auth.transport.requests import Request
+        credentials.refresh(Request())
+
+
     # The YTMusic library requires both the credentials object and a JSON representation.
     return YTMusic(auth=credentials.to_json(), oauth_credentials=credentials)
 


### PR DESCRIPTION
The `ytmusicapi` library was failing when trying to create a `RefreshingToken` with expired credentials.

This commit adds a check to refresh the Google OAuth token if it has expired before passing it to the `YTMusic` constructor. This ensures that the client is always initialized with a valid token.

## Sourcery Özeti

Hata Düzeltmeleri:
- Süresi dolmuş Google OAuth belirtecini, kimlik bilgilerini YTMusic yapıcısına geçirmeden önce yenile

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Refresh expired Google OAuth token before passing credentials to the YTMusic constructor

</details>