### PR TITLE
fix(ui): Remove YouTube Music button from UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,14 +44,6 @@
 
             <div class="my-6 border-t border-gray-700"></div>
 
-            <!-- Navigation to YT Music -->
-            <div class="mb-6">
-                <p class="text-lg mb-3">Ready to sync to YouTube Music?</p>
-                <a href="/ytmusic" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg transition-colors">
-                    Go to YouTube Music Sync
-                </a>
-            </div>
-
             <!-- Dashboard Content -->
             <div id="dashboard" class="text-left p-6 rounded-lg bg-gray-800/50 mb-6">
                 <div class="flex justify-between items-center mb-4">


### PR DESCRIPTION
This commit removes the 'Go to YouTube Music Sync' button from the main page (`templates/index.html`) to reflect the removal of the YouTube Music functionality from the backend.

## Sourcery Özeti

Hata Düzeltmeleri:
- Arka uç işlevselliğiyle eşleşmesi için YouTube Müzik Senkronizasyon düğmesini ana sayfa kullanıcı arayüzünden kaldırın

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove the YouTube Music Sync button from the main page UI to match backend functionality

</details>